### PR TITLE
Enforce user-scoped data source ownership

### DIFF
--- a/app/api/datasources/active/route.ts
+++ b/app/api/datasources/active/route.ts
@@ -1,0 +1,32 @@
+import { NextRequest, NextResponse } from "next/server";
+import { prisma } from "@/lib/db";
+import { getUserOrgFromRequest } from "@/lib/auth-server";
+
+export async function GET(req: NextRequest) {
+  const context = await getUserOrgFromRequest(req);
+  if (!context) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const { user, org } = context;
+  const datasource = await prisma.dataSource.findFirst({
+    where: { orgId: org.id, ownerId: user.id },
+    orderBy: { updatedAt: "desc" },
+  });
+
+  return NextResponse.json({
+    org: { id: org.id, name: org.name },
+    user: { id: user.id, email: user.email, name: user.name },
+    datasource: datasource
+      ? {
+          id: datasource.id,
+          name: datasource.name,
+          type: datasource.type,
+          host: datasource.host,
+          port: datasource.port,
+          database: datasource.database,
+          user: datasource.user,
+        }
+      : null,
+  });
+}

--- a/lib/auth-server.ts
+++ b/lib/auth-server.ts
@@ -1,4 +1,6 @@
 import { NextRequest } from "next/server";
+import type { Org, User } from "@prisma/client";
+import { prisma } from "@/lib/db";
 import { verifyIdToken } from "@/lib/firebase/admin";
 
 export type AuthUser = { uid: string; email?: string | null } | null;
@@ -14,4 +16,60 @@ export async function getUserFromRequest(req: NextRequest): Promise<AuthUser> {
   } catch {
     return null;
   }
+}
+
+export type AppUserContext = { user: User; org: Org };
+
+export async function getOrCreateUserOrg(uid: string, email?: string | null): Promise<AppUserContext> {
+  return prisma.$transaction(async (tx) => {
+    let user = await tx.user.findUnique({ where: { id: uid } });
+    if (!user) {
+      user = await tx.user.create({
+        data: {
+          id: uid,
+          email: email ?? undefined,
+          name: email ?? undefined,
+        },
+      });
+    } else if (email && user.email !== email) {
+      user = await tx.user.update({
+        where: { id: uid },
+        data: {
+          email,
+          name: user.name ?? email,
+        },
+      });
+    }
+
+    let org: Org | null = null;
+    if (user.orgId) {
+      org = await tx.org.findUnique({ where: { id: user.orgId } });
+    }
+
+    if (!org) {
+      org = await tx.org.create({
+        data: {
+          name: user.email ? `${user.email}'s Workspace` : `Workspace ${uid.slice(0, 8)}`,
+        },
+      });
+      user = await tx.user.update({
+        where: { id: user.id },
+        data: { orgId: org.id },
+      });
+    } else if (!user.orgId) {
+      user = await tx.user.update({
+        where: { id: user.id },
+        data: { orgId: org.id },
+      });
+    }
+
+    return { user, org };
+  });
+}
+
+export async function getUserOrgFromRequest(req: NextRequest): Promise<(AppUserContext & { auth: NonNullable<AuthUser> }) | null> {
+  const auth = await getUserFromRequest(req);
+  if (!auth) return null;
+  const context = await getOrCreateUserOrg(auth.uid, auth.email);
+  return { ...context, auth };
 }

--- a/src/hooks/useActiveDataSource.ts
+++ b/src/hooks/useActiveDataSource.ts
@@ -1,0 +1,77 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+
+type ActiveDataSourceResponse = {
+  org: { id: string; name: string | null };
+  user: { id: string; email: string | null; name: string | null };
+  datasource: {
+    id: string;
+    name: string | null;
+    type: string | null;
+    host: string | null;
+    port: number | null;
+    database: string | null;
+    user: string | null;
+  } | null;
+};
+
+type ActiveDataSourceState = ActiveDataSourceResponse | null;
+
+type UseActiveDataSourceResult = {
+  data: ActiveDataSourceState;
+  loading: boolean;
+  error: string | null;
+  refresh: () => Promise<ActiveDataSourceState>;
+};
+
+async function getIdToken(): Promise<string | undefined> {
+  try {
+    const { auth } = await import("@/lib/firebase/client");
+    if (!auth.currentUser) return undefined;
+    return await auth.currentUser.getIdToken();
+  } catch {
+    return undefined;
+  }
+}
+
+export function useActiveDataSource(): UseActiveDataSourceResult {
+  const [data, setData] = useState<ActiveDataSourceState>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const refresh = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const idToken = await getIdToken();
+      const headers: Record<string, string> = {};
+      if (idToken) headers.Authorization = `Bearer ${idToken}`;
+      const res = await fetch("/api/datasources/active", { headers, cache: "no-store" });
+      let payload: ActiveDataSourceResponse | null = null;
+      try {
+        payload = await res.json();
+      } catch {
+        payload = null;
+      }
+      if (!res.ok) {
+        throw new Error((payload as any)?.error || "Failed to load active data source");
+      }
+      setData(payload);
+      return payload;
+    } catch (err: any) {
+      const message = err?.message || "Failed to load active data source";
+      setError(message);
+      setData(null);
+      return null;
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    refresh();
+  }, [refresh]);
+
+  return { data, loading, error, refresh };
+}


### PR DESCRIPTION
## Summary
- add a server helper that ensures Firebase users have persisted User/Org records and expose an endpoint to read the active datasource
- enforce org/owner ownership in datasource, query, and schema APIs while ignoring client supplied org identifiers
- update the client to fetch the active datasource/org from the server instead of relying on localStorage state

## Testing
- npm run lint *(fails: Next.js lint prompts for configuration interactively)*

------
https://chatgpt.com/codex/tasks/task_e_68dbd3a9ef20832f8ddf0396b7907f64