### PR TITLE
Improve guardrails quoted identifier handling

### DIFF
--- a/lib/guardrails.test.ts
+++ b/lib/guardrails.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'vitest';
+
+import { validateSql } from './guardrails';
+
+describe('validateSql table allowlist', () => {
+  it('rejects disallowed quoted tables', () => {
+    const result = validateSql('SELECT * FROM "pg_catalog"."pg_authid"', ['public.safe_table']);
+    expect(result).toEqual({ ok: false, reason: 'Table not allowed: "pg_catalog"."pg_authid"' });
+  });
+
+  it('allows quoted tables present in the allowlist', () => {
+    const result = validateSql('SELECT * FROM "Public"."My_Table" AS t', ['public.my_table']);
+    expect(result).toEqual({ ok: true });
+  });
+
+  it('handles doubled quotes inside identifiers', () => {
+    const result = validateSql('SELECT * FROM "My""Schema"."My""Table"', ['"My""Schema"."My""Table"']);
+    expect(result).toEqual({ ok: true });
+  });
+});

--- a/lib/guardrails.ts
+++ b/lib/guardrails.ts
@@ -2,6 +2,26 @@ const FORBIDDEN = [
   /\b(insert|update|delete|drop|alter|create|truncate|grant|revoke|call|execute|copy|vacuum|analyze|reset|set|show|explain|listen|unlisten|notify)\b/i,
 ];
 
+const IDENTIFIER_PATTERN_SOURCE = '"(?:""|[^"])*"|[a-zA-Z_][\\w$]*';
+
+function normalizeIdentifier(identifier: string): string {
+  let trimmed = identifier.trim();
+  if (trimmed.startsWith('"') && trimmed.endsWith('"')) {
+    trimmed = trimmed.slice(1, -1).replace(/""/g, '"');
+  }
+  return trimmed.toLowerCase();
+}
+
+function getIdentifierParts(value: string): string[] | null {
+  return value.match(new RegExp(IDENTIFIER_PATTERN_SOURCE, 'g'));
+}
+
+function normalizeTableIdentifier(identifier: string): string {
+  const parts = getIdentifierParts(identifier);
+  if (!parts) return normalizeIdentifier(identifier);
+  return parts.map((part) => normalizeIdentifier(part)).join('.');
+}
+
 export function validateSql(sqlInput: string, allowedTables: string[]): { ok: true } | { ok: false; reason: string } {
   const sql = sqlInput.trim().replace(/;+\s*$/g, "");
   if (!/^with\s|^select\s/i.test(sql)) return { ok: false, reason: "Only SELECT (or WITH ... SELECT) allowed" };
@@ -9,20 +29,48 @@ export function validateSql(sqlInput: string, allowedTables: string[]): { ok: tr
   for (const r of FORBIDDEN) if (r.test(sql)) return { ok: false, reason: "Statement contains forbidden keywords" };
 
   // Basic table allowlist: collect tokens after FROM/JOIN
-  const tableTokens = new Set<string>();
-  const fromJoinRe = /(from|join)\s+([a-zA-Z_][\w\.]*)(?:\s+as\s+\w+|\s+\w+)?/gi;
+  const tableTokens = new Map<string, string>();
+  const fromJoinRe = /\b(from|join)\b/gi;
+  const tablePattern = new RegExp(
+    `^\\s*(?:${IDENTIFIER_PATTERN_SOURCE})(?:\\s*\\.\\s*(?:${IDENTIFIER_PATTERN_SOURCE}))?`,
+  );
   let m: RegExpExecArray | null;
   while ((m = fromJoinRe.exec(sql)) !== null) {
-    const t = m[2]!;
-    const base = t.includes(".") ? t : t; // allow public.
-    tableTokens.add(base.toLowerCase());
+    const rest = sql.slice(fromJoinRe.lastIndex);
+    const tableMatch = rest.match(tablePattern);
+    if (!tableMatch) continue;
+    const raw = tableMatch[0]!.trim();
+    const identifiers = getIdentifierParts(raw);
+    if (!identifiers || identifiers.length === 0) continue;
+    const normalizedParts = identifiers.map((part) => normalizeIdentifier(part));
+    const normalized = normalizedParts.join('.');
+    if (!tableTokens.has(normalized)) {
+      tableTokens.set(normalized, raw.trim());
+    }
   }
   if (tableTokens.size > 0) {
-    const allowedLower = new Set(allowedTables.map((t) => t.toLowerCase()));
-    for (const t of tableTokens) {
-      const base = t.includes(".") ? t : t; // if schema omitted, assume public
-      if (!(allowedLower.has(base) || allowedLower.has(`public.${base}`) || allowedLower.has(base.replace(/^public\./, "")))) {
-        return { ok: false, reason: `Table not allowed: ${t}` };
+    const allowedLower = new Set(allowedTables.map((t) => normalizeTableIdentifier(t)));
+    for (const [normalized, raw] of tableTokens) {
+      const hasSchema = normalized.includes('.');
+      const tableOnly = normalized.split('.').pop()!;
+      const candidates = new Set<string>([tableOnly, `public.${tableOnly}`]);
+      if (hasSchema) {
+        candidates.add(normalized);
+        if (normalized.startsWith('public.')) {
+          candidates.add(normalized.slice('public.'.length));
+        }
+      }
+
+      let allowed = false;
+      for (const candidate of candidates) {
+        if (allowedLower.has(candidate)) {
+          allowed = true;
+          break;
+        }
+      }
+
+      if (!allowed) {
+        return { ok: false, reason: `Table not allowed: ${raw}` };
       }
     }
   }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -5,6 +5,6 @@ export default defineConfig({
   plugins: [tsconfigPaths()],
   test: {
     environment: "node",
-    include: ["tests/**/*.test.ts"],
+    include: ["tests/**/*.test.ts", "lib/**/*.test.ts"],
   },
 });


### PR DESCRIPTION
## Summary
- update SQL guardrails to parse quoted identifiers, normalize them, and compare against the allowlist reliably
- add regression coverage for quoted tables and allow quoted tests to run by updating the Vitest config

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68dbe67cc9a8832f99a1960139a5601f