### PR TITLE
Improve data source hydration across client and API

### DIFF
--- a/app/api/datasources/list/route.ts
+++ b/app/api/datasources/list/route.ts
@@ -1,0 +1,28 @@
+import { NextRequest, NextResponse } from "next/server";
+import { prisma } from "@/lib/db";
+import { getUserFromRequest } from "@/lib/auth-server";
+import { ensureUserAndOrg } from "@/lib/userOrg";
+import { redactDataSourceSecrets } from "@/lib/datasourceSecrets";
+
+export async function GET(req: NextRequest) {
+  const authUser = await getUserFromRequest(req);
+  if (!authUser) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const { user } = await ensureUserAndOrg(authUser);
+
+  const dataSources = await prisma.dataSource.findMany({
+    where: {
+      OR: [
+        { ownerId: user.id },
+        { org: { users: { some: { id: user.id } } } },
+      ],
+    },
+    orderBy: { createdAt: "desc" },
+  });
+
+  return NextResponse.json({
+    dataSources: dataSources.map((ds) => redactDataSourceSecrets(ds)),
+  });
+}

--- a/lib/datasource.ts
+++ b/lib/datasource.ts
@@ -1,7 +1,11 @@
+import type { DataSource } from "@prisma/client";
 import { prisma } from "@/lib/db";
 import { redactDataSourceSecrets } from "@/lib/datasourceSecrets";
 
 export async function getUserDataSources(userId: string) {
-  const rows = await prisma.dataSource.findMany({ where: { ownerId: userId }, orderBy: { createdAt: "desc" } });
-  return rows.map((row) => redactDataSourceSecrets(row));
+  const rows: DataSource[] = await prisma.dataSource.findMany({
+    where: { ownerId: userId },
+    orderBy: { createdAt: "desc" },
+  });
+  return rows.map((row: DataSource) => redactDataSourceSecrets(row));
 }

--- a/src/lib/datasourceClient.ts
+++ b/src/lib/datasourceClient.ts
@@ -1,0 +1,53 @@
+export type DataSourceSummary = {
+  id: string;
+  orgId: string | null;
+  name: string;
+  host: string | null;
+  port: number | null;
+  database: string | null;
+  user: string | null;
+  hasPassword?: boolean;
+  createdAt?: string;
+  updatedAt?: string;
+};
+
+async function getIdToken(): Promise<string | undefined> {
+  const firebase = await import("@/lib/firebase/client");
+  const currentUser = firebase.auth.currentUser;
+  if (!currentUser) return undefined;
+  try {
+    return await currentUser.getIdToken();
+  } catch {
+    return undefined;
+  }
+}
+
+export async function fetchAccessibleDataSources(): Promise<DataSourceSummary[]> {
+  const idToken = await getIdToken();
+  const res = await fetch("/api/datasources/list", {
+    method: "GET",
+    headers: {
+      "Content-Type": "application/json",
+      ...(idToken ? { Authorization: `Bearer ${idToken}` } : {}),
+    },
+    cache: "no-store",
+  });
+
+  let payload: any = null;
+  try {
+    payload = await res.json();
+  } catch {
+    payload = null;
+  }
+
+  if (!res.ok) {
+    if (res.status === 401) {
+      return [];
+    }
+    const message = payload?.error || `Failed to load data sources (${res.status})`;
+    throw new Error(message);
+  }
+
+  const list = Array.isArray(payload?.dataSources) ? payload.dataSources : [];
+  return list as DataSourceSummary[];
+}


### PR DESCRIPTION
## Summary
- add an authenticated API endpoint to list data sources the current user can access
- hydrate the settings, home page, and query client from the API so saved connections reappear automatically
- share a client-side helper for fetching data sources and tighten datasource typings

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68dbebb09cfc832fbb1495da94f31966