### PR TITLE
Fix datasource list type annotation

### DIFF
--- a/app/api/datasources/list/route.ts
+++ b/app/api/datasources/list/route.ts
@@ -23,6 +23,8 @@ export async function GET(req: NextRequest) {
   });
 
   return NextResponse.json({
-    dataSources: dataSources.map((ds) => redactDataSourceSecrets(ds)),
+    dataSources: dataSources.map((ds: (typeof dataSources)[number]) =>
+      redactDataSourceSecrets(ds)
+    ),
   });
 }


### PR DESCRIPTION
## Summary
- add an explicit type when mapping data sources so TypeScript no longer reports an implicit any error

## Testing
- npm run build *(fails: Next.js lockfile patch requires fetching SWC binaries without network access)*

------
https://chatgpt.com/codex/tasks/task_e_68dc0fb7c62c832fbb2a48dbfaa4460d